### PR TITLE
Corey417

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -30,11 +30,13 @@ var formSubmitHandler = function(event) {
             // searchMovieInfo (character)
             // $('#movie-details').empty();
             $('#character-cast').empty();  
+            $('#character-bio').empty();  
+            $('#movie-search-display').empty();  
+            $('#tvshow-search-display').empty();  
         }
         
     }
 }
-
 
 // BEGIN THE themoviedb.org API
 // function to search for person (character) from themoviedb.org

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -28,7 +28,8 @@ var formSubmitHandler = function(event) {
             theMovieDbSearch(character)
             // getTheMoviedpAPIs(character)
             // searchMovieInfo (character)
-            // $('#movie-details').empty();  
+            // $('#movie-details').empty();
+            $('#character-cast').empty();  
         }
         
     }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Entertaiment Finder</title>
+    <title>AMDB</title>
   <!-- foundation-float.min.css: Compressed CSS with legacy Float Grid -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/foundation-sites@6.7.4/dist/css/foundation-float.min.css" crossorigin="anonymous">
 
@@ -24,14 +24,14 @@
         <div class="top-bar">
             <!-- left side of nav -->
             <div class="top-bar-left">
-               <a href="index.html"><h1> Entertaiment Finder </h1>  </a>    
+               <a href="index.html"><h1>Actor + Movie Database</h1>  </a>    
             </div>
              <!-- right side of nav -->
             <div class="top-bar-right">  
                 <!-- search bar-->    
                 <form id="search-form">                     
                     <ul class="menu">                         
-                        <li><input class="input" id ="character" name="character" placeholderid="character" type="text" value="Spider Man" autofocus="true" /></li>
+                        <li><input class="input" id ="character" name="character" placeholderid="character" type="text" value="Enter Your Search Here" autofocus="true" /></li>
                         <li><button class="button" type="submit" id="search-button">Search</button></li> 
                     </ul>              
                 </form>                                        


### PR DESCRIPTION
Edited the HTML to display Actor + Movie Database in Title and Header areas as well as adjusted the pretext in search box from Spider Man to Enter Search Here.

Edited the JS to correct discovered issues when testing. In short, when searching actors, their movies would display below as they should, however, when searching a new actor, the movies would remain and the NEW search's movies would ADD to the list of the previous actors search, not replace it. 
Added a clear command to erase all previously searched actors movies with the new actor's movies. 

Came across an identical issue with tv show and movie searches and took a snippit of how it looked before.
![EX](https://user-images.githubusercontent.com/96207382/163743936-684b8c73-a197-4ddf-9dfb-c2f6e7dc5fc6.PNG)
Three completely unrelated shows on screen after separate searches (Invader Zim, Cheers, and Three Stooges).
Added code so, like actors movies, previously searched items will be replaced with new search items.
(NOTE: Each element needed its own clear data command because I was unable to have it work off its parent element.)

